### PR TITLE
Fix iOS code signing in GitHub Actions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -68,8 +68,12 @@ jobs:
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       env:
         DEVELOPMENT_TEAM: ${{ secrets.DEVELOPMENT_TEAM }}
+        CI: true
       run: |
         cd ios
+        # Reinstall pods with CI flag to apply code signing changes
+        pod install
+        
         xcodebuild -workspace autopassmobileexample.xcworkspace \
           -scheme autopassmobileexample \
           -configuration Release \
@@ -79,6 +83,7 @@ jobs:
           -allowProvisioningUpdates \
           DEVELOPMENT_TEAM="$DEVELOPMENT_TEAM" \
           CODE_SIGNING_ALLOWED=YES \
+          CODE_SIGN_IDENTITY="Apple Distribution" \
           archive
     
     - name: Export IPA

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -62,5 +62,17 @@ target 'autopassmobileexample' do
         end
       end
     end
+
+    # Disable code signing for all pods when building in CI
+    if ENV['CI']
+      installer.pods_project.targets.each do |target|
+        target.build_configurations.each do |config|
+          config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+          config.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+          config.build_settings['CODE_SIGN_IDENTITY'] = ''
+          config.build_settings['EXPANDED_CODE_SIGN_IDENTITY'] = ''
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Fixes code signing issues that prevented TestFlight deployment in GitHub Actions
- Adds CI-specific configuration to disable Pod signing

## Changes
- Updated Podfile to disable code signing for all Pod targets when `CI=true`
- Modified GitHub workflow to set CI environment variable and reinstall pods

## Test plan
- [x] PR build should pass (simulator build)
- [ ] Push to main should successfully deploy to TestFlight

🤖 Generated with [Claude Code](https://claude.ai/code)